### PR TITLE
Marking methods of EmailService that implement IEmailService as virtual.

### DIFF
--- a/src/Postal/EmailService.cs
+++ b/src/Postal/EmailService.cs
@@ -35,7 +35,7 @@ namespace Postal
         readonly IEmailParser emailParser;
         readonly Func<SmtpClient> createSmtpClient;
 
-        public void Send(Email email)
+        public virtual void Send(Email email)
         {
             using (var mailMessage = CreateMailMessage(email))
             using (var smtp = createSmtpClient())
@@ -44,7 +44,7 @@ namespace Postal
             }
         }
 
-        public Task SendAsync(Email email)
+        public virtual Task SendAsync(Email email)
         {
             // Wrap the SmtpClient's awkward async API in the much nicer Task pattern.
             // However, we must be careful to dispose of the resources we create correctly.
@@ -91,7 +91,7 @@ namespace Postal
             }
         }
 
-        public MailMessage CreateMailMessage(Email email)
+        public virtual MailMessage CreateMailMessage(Email email)
         {
             var rawEmailString = emailViewRenderer.Render(email);
             var mailMessage = emailParser.Parse(rawEmailString, email);


### PR DESCRIPTION
This is another quick one.

I wanted to replace the SmtpClient implementation with Amazon SES and tried to subclass from `EmailService` so as to not write the `CreateMailMessage` method again. That meant that I had to mark my `Send` and `SendAsync` methods as `new`. It turns out, however, that these `new`methods are not called if one uses the `IEmailService` interface to call methods. I had to find that out the hard way. :)

So the change marks methods of `EmailService` that implement `IEmailService` as virtual so that library consumers can subclass `EmailService` to make minor modifications by overriding stock methods.
