### PR TITLE
Fix for sending emails in separate threads

### DIFF
--- a/src/Postal/EmailHttpRequest.cs
+++ b/src/Postal/EmailHttpRequest.cs
@@ -69,14 +69,13 @@ namespace Postal
 
         static HttpBrowserCapabilitiesWrapper CreateHttpBrowserCapabilities()
         {
-            return new HttpBrowserCapabilitiesWrapper(
-                HttpContext.Current == null
-                    ? new HttpBrowserCapabilities()
-                    : new HttpBrowserCapabilities
-                    {
-                        Capabilities = HttpContext.Current.Request.Browser.Capabilities
-                    }
-            );
+			var factory = new System.Web.Configuration.BrowserCapabilitiesFactory();
+			var browserCapabilities = new HttpBrowserCapabilities();
+
+			browserCapabilities.Capabilities = HttpContext.Current != null ? HttpContext.Current.Request.Browser.Capabilities : new System.Collections.Hashtable();
+
+			factory.ConfigureBrowserCapabilities(new NameValueCollection(), browserCapabilities);
+			return new HttpBrowserCapabilitiesWrapper(browserCapabilities);
         }
     }
 }


### PR DESCRIPTION
Currently running in .NET 4.5, if I try to send an email on a different thread I get a null reference exception on the browser capabilities (in particular checking to see if it's a mobile browser).

This ensures that the capabilities object is created properly.
