### PR TITLE
Making the nuspec match the project

### DIFF
--- a/build/Postal.Mvc4.nuspec
+++ b/build/Postal.Mvc4.nuspec
@@ -18,7 +18,7 @@
     </frameworkAssemblies>
     <dependencies>
       <dependency id="Microsoft.AspNet.Mvc" version="4.0.30506.0" />
-      <dependency id="RazorEngine" version="[2.1,3.0)" />
+      <dependency id="RazorEngine" version="3.3.0" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Fix for Issue #83 
Updating the `Postal.Mvc4.nuspec` file to match the project reference in the mvc4 project.
After repackaging this Nuget with this change and hosting it in a local feed, it fixed the exceptions we were getting.
