### PR TITLE
Support views stored in Areas

### DIFF
--- a/src/Postal/Email.cs
+++ b/src/Postal/Email.cs
@@ -30,6 +30,17 @@ namespace Postal
             ImageEmbedder = new ImageEmbedder();
         }
 
+        /// <summary>
+        /// Creates a new Email, that will render the given view.
+        /// </summary>
+        /// <param name="viewName">The name of the view to render</param>
+        /// <param name="areaName">The name of the area containing the view to render</param>
+        public Email(string viewName, string areaName)
+            : this(viewName)
+        {
+            AreaName = areaName;
+        }
+
         /// <summary>Create an Email where the ViewName is derived from the name of the class.</summary>
         /// <remarks>Used when defining strongly typed Email classes.</remarks>
         protected Email()
@@ -44,6 +55,11 @@ namespace Postal
         /// The name of the view containing the email template.
         /// </summary>
         public string ViewName { get; set; }
+
+        /// <summary>
+        /// The name of the area containing the email template.
+        /// </summary>
+        public string AreaName { get; set; }
 
         /// <summary>
         /// The view data to pass to the view.

--- a/src/Postal/EmailViewRenderer.cs
+++ b/src/Postal/EmailViewRenderer.cs
@@ -38,13 +38,18 @@ namespace Postal
         public string Render(Email email, string viewName = null)
         {
             viewName = viewName ?? email.ViewName;
-            var controllerContext = CreateControllerContext();
+            var controllerContext = CreateControllerContext(email.AreaName);
             var view = CreateView(viewName, controllerContext);
             var viewOutput = RenderView(view, email.ViewData, controllerContext, email.ImageEmbedder);
             return viewOutput;
         }
 
-        ControllerContext CreateControllerContext()
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="areaName">The name of the area containing the Emails view folder if applicable</param>
+        /// <returns></returns>
+        ControllerContext CreateControllerContext(string areaName)
         {
             // A dummy HttpContextBase that is enough to allow the view to be rendered.
             var httpContext = new HttpContextWrapper(
@@ -55,6 +60,11 @@ namespace Postal
             );
             var routeData = new RouteData();
             routeData.Values["controller"] = EmailViewDirectoryName;
+
+            // if populated will add searching Areas for the view
+            if (!string.IsNullOrWhiteSpace(areaName))
+                routeData.DataTokens["Area"] = areaName;
+
             var requestContext = new RequestContext(httpContext, routeData);
             var stubController = new StubController();
             var controllerContext = new ControllerContext(requestContext, stubController);

--- a/src/Postal/EmailViewRenderer.cs
+++ b/src/Postal/EmailViewRenderer.cs
@@ -61,7 +61,7 @@ namespace Postal
             var routeData = new RouteData();
             routeData.Values["controller"] = EmailViewDirectoryName;
 
-            // if populated will add searching Areas for the view
+            // if populated will add searching the named Area for the view
             if (!string.IsNullOrWhiteSpace(areaName))
                 routeData.DataTokens["Area"] = areaName;
 


### PR DESCRIPTION
We are using Areas for a project and wanted to be able to have the Emails folder stored in the Area instead of off the root.  

This change lets you add the name of an Area to the Email object using either a new constructor or by using an AreaName property.  If populated, the EmailViewRender puts the AreaName in the DataTokens of the RouteData object.  Once there, the folder  ~/[AreaName]Views/Emails/ is included in the search for the view named in the Email object.
