### PR TITLE
HtmlHelper attributes and embedded images content type

### DIFF
--- a/src/Postal/HtmlExtensions.cs
+++ b/src/Postal/HtmlExtensions.cs
@@ -16,23 +16,45 @@ namespace Postal
         /// <param name="imagePathOrUrl">An image file path or URL. A file path can be relative to the web application root directory.</param>
         /// <param name="alt">The content for the &lt;img alt&gt; attribute.</param>
         /// <returns>An HTML &lt;img&gt; tag.</returns>
-        public static IHtmlString EmbedImage(this HtmlHelper html, string imagePathOrUrl, string alt = "")
+        [Obsolete( "Use second method overload" )]
+        public static IHtmlString EmbedImage( this HtmlHelper html, string imagePathOrUrl, string alt = "" )
         {
-            if (string.IsNullOrWhiteSpace(imagePathOrUrl)) throw new ArgumentException("Path or URL required", "imagePathOrUrl");
-
-            if (IsFileName(imagePathOrUrl))
-            {
-                imagePathOrUrl = html.ViewContext.HttpContext.Server.MapPath(imagePathOrUrl);
-            }
-            var imageEmbedder = (ImageEmbedder)html.ViewData[ImageEmbedder.ViewDataKey];
-            var resource = imageEmbedder.ReferenceImage(imagePathOrUrl);
-            return new HtmlString(string.Format("<img src=\"cid:{0}\" alt=\"{1}\"/>", resource.ContentId, html.AttributeEncode(alt)));
+            return EmbedImage( html, imagePathOrUrl, new { alt = alt } );
         }
 
-        static bool IsFileName(string pathOrUrl)
+        /// <summary>
+        /// Embeds the given image into the email and returns an HTML &lt;img&gt; tag referencing the image.
+        /// </summary>
+        /// <param name="html">The <see cref="HtmlHelper"/>.</param>
+        /// <param name="imagePathOrUrl">An image file path or URL. A file path can be relative to the web application root directory.</param>
+        /// <param name="htmlAttributes">An object that contains the HTML attributes to set for the element.</param>
+        /// <returns>An HTML &lt;img&gt; tag.</returns>
+        public static IHtmlString EmbedImage( this HtmlHelper html, string imagePathOrUrl, object htmlAttributes = null )
         {
-            return !(pathOrUrl.StartsWith("http:", StringComparison.OrdinalIgnoreCase)
-                     || pathOrUrl.StartsWith("https:", StringComparison.OrdinalIgnoreCase));
+            if (string.IsNullOrWhiteSpace( imagePathOrUrl )) throw new ArgumentException( "Path or URL required", "imagePathOrUrl" );
+
+            if (IsFileName( imagePathOrUrl ))
+            {
+                imagePathOrUrl = html.ViewContext.HttpContext.Server.MapPath( imagePathOrUrl );
+            }
+            var imageEmbedder = (ImageEmbedder)html.ViewData[ImageEmbedder.ViewDataKey];
+            var resource = imageEmbedder.ReferenceImage( imagePathOrUrl );
+
+            var img = new TagBuilder( "img" );
+
+            if (htmlAttributes is string) // method overload back compatibility
+                img.MergeAttribute( "alt", (string)htmlAttributes );
+            else
+                img.MergeAttributes( HtmlHelper.AnonymousObjectToHtmlAttributes( htmlAttributes ) );
+
+            img.MergeAttribute( "src", String.Format( "cid:{0}", resource.ContentId ), true );
+            return new MvcHtmlString( img.ToString( TagRenderMode.SelfClosing ) );
+        }
+
+        static bool IsFileName( string pathOrUrl )
+        {
+            return !(pathOrUrl.StartsWith( "http:", StringComparison.OrdinalIgnoreCase )
+                     || pathOrUrl.StartsWith( "https:", StringComparison.OrdinalIgnoreCase ));
         }
     }
 }

--- a/src/Postal/ImageEmbedder.cs
+++ b/src/Postal/ImageEmbedder.cs
@@ -54,7 +54,17 @@ namespace Postal
             {
                 var client = new WebClient();
                 var bytes = client.DownloadData(imagePathOrUrl);
-                return new LinkedResource(new MemoryStream(bytes));
+
+                // get content type from response
+                string contentType = client.ResponseHeaders[HttpResponseHeader.ContentType];
+                if (!String.IsNullOrWhiteSpace( contentType ))
+                {
+                    return new LinkedResource( new MemoryStream( bytes ), new ContentType( contentType ) );
+                }
+                else
+                {
+                    return new LinkedResource( new MemoryStream( bytes ));
+                }
             }
             else
             {


### PR DESCRIPTION
In our project we needed these two features:
- "style" attribute of embedded images in email
- embedding dynamically generated images without file extensions - that's why we implemented content type recognizing by response header
