### PR TITLE
Separate service and viewmodel

### DIFF
--- a/src/Postal/Email.cs
+++ b/src/Postal/Email.cs
@@ -30,6 +30,23 @@ namespace Postal
             ImageEmbedder = new ImageEmbedder();
         }
 
+        /// <summary>
+        /// Creates a new Email, that will render the given view using the given model.
+        /// </summary>
+        /// <param name="viewName">The name of the view to render</param>
+        /// <param name="model">The view's model</param>
+        public Email(string viewName, object model)
+        {
+          if (viewName == null) throw new ArgumentNullException("viewName");
+          if (string.IsNullOrWhiteSpace(viewName)) throw new ArgumentException("View name cannot be empty.", "viewName");
+          if (model == null) throw new ArgumentNullException("model");
+
+          Attachments = new List<Attachment>();
+          ViewName = viewName;
+          ViewData = new ViewDataDictionary(model);
+          ImageEmbedder = new ImageEmbedder();
+        }
+
         /// <summary>Create an Email where the ViewName is derived from the name of the class.</summary>
         /// <remarks>Used when defining strongly typed Email classes.</remarks>
         protected Email()

--- a/src/Postal/EmailService.cs
+++ b/src/Postal/EmailService.cs
@@ -55,6 +55,20 @@ namespace Postal
         }
 
         /// <summary>
+        /// Sends an email using an <see cref="SmtpClient"/>.
+        /// </summary>
+        /// <param name="email">The email to send.</param>
+        /// <param name="viewName">The name of the view to render.</param>
+        public void Send(string viewName, Email email)
+        {
+            using (var mailMessage = CreateMailMessage(viewName, email))
+            using (var smtp = createSmtpClient())
+            {
+                smtp.Send(mailMessage);
+            }
+        }
+
+        /// <summary>
         /// Send an email asynchronously, using an <see cref="SmtpClient"/>.
         /// </summary>
         /// <param name="email">The email to send.</param>
@@ -117,5 +131,21 @@ namespace Postal
             var mailMessage = emailParser.Parse(rawEmailString, email);
             return mailMessage;
         }
+
+        /// <summary>
+        /// Renders the email view and builds a <see cref="MailMessage"/>. Does not send the email.
+        /// </summary>
+        /// <param name="email">The email to render.</param>
+        /// <param name="viewName">The name of the view to render.</param>
+        /// <returns>A <see cref="MailMessage"/> containing the rendered email.</returns>
+        public MailMessage CreateMailMessage(string viewName, Email email)
+        {
+            var rawEmailString = emailViewRenderer.Render(email, viewName);
+            var mailMessage = emailParser.Parse(rawEmailString, email);
+            return mailMessage;
+        }
+
+
+
     }
 }


### PR DESCRIPTION
We have a common base class for all viewmodels. So a viewmodel cannot inherit from that base class and from `Postal.Email`.

Seems others have this problem as well: [see here](https://github.com/andrewdavey/postal/issues/52), [and here](https://github.com/andrewdavey/postal/pull/105).

This pull request allows you to do this:

```
var viewName  = "~/Views/Foo/Index.cshtml";
var viewModel = new FooViewModel();
var service   = new EmailService();
service.Send(viewName, viewModel);
```

By adding overloads as I did, it also means that it's backwards compatible for those who want to carry on using it as is.

What do you think?
