### PR TITLE
Basic support for layouts outside MVC.

### DIFF
--- a/src/Postal.Tests/FileSystemRazorViewTests.cs
+++ b/src/Postal.Tests/FileSystemRazorViewTests.cs
@@ -40,5 +40,33 @@ namespace Postal
                 File.Delete(filename);
             }
         }
+
+        [Fact]
+        public void Layout_template_is_supported()
+        {
+            var tempPath = Path.GetTempPath();
+            var layoutFilename = Path.Combine(tempPath, "layout.cshtml");
+            var bodyFilename = Path.Combine(tempPath, "body.cshtml");
+            File.WriteAllText(layoutFilename, "layout-test\r\n@RenderBody()");
+            File.WriteAllText(bodyFilename, "@{Layout=\"layout.cshtml\";}\r\nbody-test");
+            try
+            {
+                var engine = new FileSystemRazorViewEngine(tempPath);
+                var view = engine.FindView(null, "body", null, true).View;
+                var context = new Mock<ViewContext>();
+                context.Setup(c => c.ViewData).Returns(new ViewDataDictionary(new object()));
+                using (var writer = new StringWriter())
+                {
+                    view.Render(context.Object, writer);
+                    var content = writer.GetStringBuilder().ToString();
+                    Assert.Equal("layout-test\r\n\r\nbody-test", content);
+                }
+            }
+            finally
+            {
+                File.Delete(layoutFilename);
+                File.Delete(bodyFilename);
+            }
+        }
     }
 }

--- a/src/Postal/FileSystemRazorView.cs
+++ b/src/Postal/FileSystemRazorView.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 using System.Web.Mvc;
-using RazorEngine;
+using RazorEngine.Templating;
 
 namespace Postal
 {
@@ -10,15 +10,28 @@ namespace Postal
     /// </summary>
     public class FileSystemRazorView : IView
     {
+        static readonly ITemplateService DefaultRazorService = new TemplateService();
+
+        readonly ITemplateService razorService;
         readonly string template;
         readonly string cacheName;
-        
+
         /// <summary>
         /// Creates a new <see cref="FileSystemRazorView"/> using the given view filename.
         /// </summary>
         /// <param name="filename">The filename of the view.</param>
-        public FileSystemRazorView(string filename)
+        public FileSystemRazorView(string filename) : this(DefaultRazorService, filename)
         {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="FileSystemRazorView"/> using the given view filename.
+        /// </summary>
+        /// <param name="razorService">The RazorEngine ITemplateService to use to render the view</param>
+        /// <param name="filename">The filename of the view.</param>
+        public FileSystemRazorView(ITemplateService razorService, string filename)
+        {
+            this.razorService = razorService;
             template = File.ReadAllText(filename);
             cacheName = filename;
         }
@@ -30,7 +43,7 @@ namespace Postal
         /// <param name="writer">The <see cref="TextWriter"/> used to write the rendered output.</param>
         public void Render(ViewContext viewContext, TextWriter writer)
         {
-            var content = Razor.Parse(template, viewContext.ViewData.Model, cacheName);
+            var content = razorService.Parse(template, viewContext.ViewData.Model, null, cacheName);
 
             writer.Write(content);
             writer.Flush();


### PR DESCRIPTION
This is a very quick spike to get layouts working via the RazorEngine.

The layout name **must** be the path to the layout file, relative from the root path specified when constructing the `FileSystemRazorViewEngine`. (e.g. asp.net style `Layout = "~\Views\EmailLayout.cshtml"` is **not** supported).

I can put some more time into this, but before proceeding wanted to check if it's ok to upgrade the RazorEngine version used. It currently uses 3.4.1, and 3.5 introduced quite a few API changes, so I'd rather upgrade to that before writing too much code against the old API.
