### PR TITLE
Fixes typo in XML comment for default constructor.

### DIFF
--- a/src/Postal/EmailService.cs
+++ b/src/Postal/EmailService.cs
@@ -11,7 +11,7 @@ namespace Postal
     public class EmailService : IEmailService
     {
         /// <summary>
-        /// Creates a new cref="EmailService"/, using the default view engines.
+        /// Creates a new <see cref="EmailService"/>, using the default view engines.
         /// </summary>
         public EmailService() : this(ViewEngines.Engines)
         {


### PR DESCRIPTION
cref tag is missing/malformed in the XML comment for the default constructor. This is a simple patch for said typo.
